### PR TITLE
Update Minecraft Wiki link to new domain

### DIFF
--- a/json/faq.json
+++ b/json/faq.json
@@ -21,7 +21,7 @@
     },
     {
         "question": "How do I install Faithful/any resource pack?",
-        "answer": "We recommend giving [this Minecraft Wiki page](https://minecraft.fandom.com/wiki/Tutorials/Loading_a_resource_pack) a read. Add-ons and tweaks work in exactly the same way, except by applying them on top of the given base pack rather than alone.",
+        "answer": "We recommend giving [this Minecraft Wiki page](https://minecraft.wiki/w/Tutorials/Loading_a_resource_pack) a read. Add-ons and tweaks work in exactly the same way, except by applying them on top of the given base pack rather than alone.",
         "keywords": ["installation", "install"]
     },
     {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the previous fandom wiki link accordingly.