### PR TITLE
Animation for comparison

### DIFF
--- a/src/helpers/functions/getTexture.ts
+++ b/src/helpers/functions/getTexture.ts
@@ -51,7 +51,7 @@ export async function getTexture(interaction: Interaction, texture: Texture, pac
 	const [strPack, strIconURL] = formatName(pack);
 
 	const files: AttachmentBuilder[] = [];
-	let embed = new EmbedBuilder().setTitle(`[#${texture.id}] ${texture.name}`).setFooter({
+	const embed = new EmbedBuilder().setTitle(`[#${texture.id}] ${texture.name}`).setFooter({
 		text: strPack,
 		iconURL: strIconURL,
 	});
@@ -119,23 +119,18 @@ export async function getTexture(interaction: Interaction, texture: Texture, pac
 
 	// magnifying the texture in thumbnail
 	if (isAnimated) {
-		if (Object.keys(mcmeta?.animation ?? {}).length) addMCMetaToEmbed(embed, mcmeta);
+		if (Object.keys(mcmeta?.animation ?? {}).length)
+			embed.addFields({
+				name: "MCMETA",
+				value: `\`\`\`json\n${JSON.stringify(mcmeta.animation)}\`\`\``,
+			});
+
 		const { magnified } = await magnify(textureURL, { isAnimation: true });
 		files.push(await animateToAttachment(magnified, mcmeta));
 	} else files.push(await magnifyToAttachment(textureURL));
 
 	return { embeds: [embed], files: files, components: [textureButtons], ephemeral: false };
 }
-
-export const addMCMetaToEmbed = (embed: EmbedBuilder, mcmeta: MCMETA) => {
-	embed.addFields({
-		name: "MCMETA",
-		value: `\`\`\`json\n${JSON.stringify(mcmeta.animation)}\`\`\``,
-	});
-	return {
-		embed,
-	};
-};
 
 /**
  * Generate embed fields for a given texture's paths

--- a/src/helpers/functions/textureComparison.ts
+++ b/src/helpers/functions/textureComparison.ts
@@ -125,6 +125,7 @@ export default async function textureComparison(
 		const firstTileSheet = await loadImage(await stitch(stitchedFrames, 0));
 		const { magnified } = await magnify(firstTileSheet, { isAnimation: true, factor: 4 }); // 4 was chosen as a middle ground to prevent too much lag
 		const imageMagnified = await loadImage(magnified);
+		if (!mcmeta.animation) mcmeta.animation = {};
 		if (!mcmeta.animation?.height) mcmeta.animation.height = imageMagnified.height / frameCount;
 		else mcmeta.animation.height *= 4;
 		if (!mcmeta.animation?.width) mcmeta.animation.width = imageMagnified.width;

--- a/src/helpers/images/magnify.ts
+++ b/src/helpers/images/magnify.ts
@@ -18,7 +18,7 @@ export async function magnify(origin: ImageSource, options: MagnifyOptions = {})
 	const input = await loadImage(origin);
 
 	// ignore height if tilesheet, otherwise it's not scaled as much
-	const surface = options.isAnimation ? input.width * 16 : input.width * input.height;
+	const surface = options.isAnimation ? input.width * 32 : input.width * input.height;
 
 	// no custom factor provided
 	let factor = 64;

--- a/src/helpers/images/magnify.ts
+++ b/src/helpers/images/magnify.ts
@@ -18,8 +18,7 @@ export async function magnify(origin: ImageSource, options: MagnifyOptions = {})
 	const input = await loadImage(origin);
 
 	// ignore height if tilesheet, otherwise it's not scaled as much
-	const surface = options.isAnimation ? input.width * 32 : input.width * input.height;
-
+	const surface = options.isAnimation ? input.width ** 2 : input.width * input.height;
 	// no custom factor provided
 	let factor = 64;
 	if (surface <= 256) factor = 32;

--- a/src/interfaces/firestorm.ts
+++ b/src/interfaces/firestorm.ts
@@ -1,3 +1,5 @@
+import { MCMETA } from "@helpers/images/animate";
+
 export type MinecraftEdition = "java" | "bedrock";
 
 export type FaithfulPack =
@@ -35,16 +37,6 @@ export interface Path {
 	versions: string[]; // texture versions
 }
 
-export interface MCMeta {
-	animation: {
-		frametime?: number;
-		interpolate?: boolean;
-		frames?: (number | { index?: number; time?: number })[];
-		height?: number;
-		width?: number;
-	};
-}
-
 export interface Use {
 	id: string;
 	name: string;
@@ -62,6 +54,7 @@ export interface Texture extends BaseTexture {
 	uses: Use[];
 	paths: Path[];
 	contributions?: Contribution[];
+	mcmeta?: MCMETA;
 }
 
 // used for comparison loader

--- a/src/interfaces/firestorm.ts
+++ b/src/interfaces/firestorm.ts
@@ -35,6 +35,16 @@ export interface Path {
 	versions: string[]; // texture versions
 }
 
+export interface MCMeta {
+	animation: {
+		frametime?: number;
+		interpolate?: boolean;
+		frames?: (number | { index?: number; time?: number })[];
+		height?: number;
+		width?: number;
+	};
+}
+
 export interface Use {
 	id: string;
 	name: string;


### PR DESCRIPTION
Closes #259 — The new code would allow animated textures to work with the /compare command. I also added in an MCMeta section to firestorm to make things easier in the future. Its not necessary but it works a little better in my opinion than declaring it as an "any".