### PR TITLE
New buttons for tiling

### DIFF
--- a/src/commands/images/tile.ts
+++ b/src/commands/images/tile.ts
@@ -13,7 +13,7 @@ export const command: SlashCommand = {
 		.addStringOption((option) =>
 			option
 				.setName("random")
-				.setDescription("Should individual tiles be randomly rotated?")
+				.setDescription("Whether individual tiles should be randomly rotated or flipped.")
 				.setRequired(false)
 				.addChoices(
 					{ name: "rotation", value: "rotation" },
@@ -35,7 +35,7 @@ export const command: SlashCommand = {
 		.addBooleanOption((option) =>
 			option
 				.setName("magnify")
-				.setDescription("Should the image get magnified?")
+				.setDescription("Whether the image should be magnified (default is true).")
 				.setRequired(false),
 		)
 		.addAttachmentOption((o) =>

--- a/src/commands/images/tile.ts
+++ b/src/commands/images/tile.ts
@@ -3,7 +3,7 @@ import { SlashCommandBuilder } from "discord.js";
 import { ChatInputCommandInteraction, Message } from "@client";
 import { tileToAttachment, TileShape, TileRandom } from "@images/tile";
 import getImage, { imageNotFound } from "@helpers/getImage";
-import { imageButtons } from "@utility/buttons";
+import { tileButtons } from "@utility/buttons";
 import { imageTooBig } from "@helpers/warnUser";
 
 export const command: SlashCommand = {
@@ -29,9 +29,14 @@ export const command: SlashCommand = {
 					{ name: "grid", value: "grid" },
 					{ name: "vertical", value: "vertical" },
 					{ name: "horizontal", value: "horizontal" },
-					{ name: "hollow", value: "hollow" },
 					{ name: "plus", value: "plus" },
 				),
+		)
+		.addBooleanOption((option) =>
+			option
+				.setName("magnify")
+				.setDescription("Should the image get magnified?")
+				.setRequired(false),
 		)
 		.addAttachmentOption((o) =>
 			o.setName("image").setDescription("The image to tile").setRequired(false),
@@ -39,20 +44,21 @@ export const command: SlashCommand = {
 	async execute(interaction: ChatInputCommandInteraction) {
 		const random = interaction.options.getString("random") as TileRandom;
 		const shape = interaction.options.getString("type") as TileShape;
+		const magnify = interaction.options.getBoolean("magnify", false) ?? true;
+		await interaction.deferReply();
 
 		const image = await getImage(interaction);
 		if (!image) return imageNotFound(interaction);
 
-		const file = await tileToAttachment(image, { random, shape });
+		const file = await tileToAttachment(image, { random, shape, magnify });
 
 		if (!file) {
 			return await imageTooBig(interaction, "tile");
 		}
 		await interaction
-			.reply({
+			.editReply({
 				files: [file],
-				components: [imageButtons],
-				fetchReply: true,
+				components: [tileButtons],
 			})
 			.then((message: Message) => message.deleteButton());
 	},

--- a/src/components/buttons/image/flip.ts
+++ b/src/components/buttons/image/flip.ts
@@ -1,0 +1,38 @@
+import { Component } from "@interfaces/components";
+import { info } from "@helpers/logger";
+import { Client, Message, ButtonInteraction, EmbedBuilder } from "@client";
+import { tileToAttachment, untile } from "@images/tile";
+import { tileButtons } from "@utility/buttons";
+import getImage, { imageNotFound } from "@helpers/getImage";
+import { imageTooBig } from "@helpers/warnUser";
+
+export default {
+	id: "flip",
+	async execute(client: Client, interaction: ButtonInteraction) {
+		if (client.verbose) console.log(`${info}Image was flipped!`);
+
+		const message = interaction.message;
+		const url = await getImage(message);
+		if (!url) return imageNotFound(interaction);
+		const image = await untile(url);
+		const attachment = await tileToAttachment(image, { random: "flip", magnify: true });
+
+		if (!attachment) return await imageTooBig(interaction, "tile");
+
+		return interaction
+			.reply({
+				embeds: [
+					new EmbedBuilder()
+						.setImage(`attachment://${attachment.name}`)
+						.setFooter({ text: `${interaction.user.username} | ${interaction.user.id}` })
+						.setTimestamp(),
+				],
+				files: [attachment],
+				components: [tileButtons],
+				fetchReply: true,
+			})
+			.then((message: Message) => {
+				message.deleteButton(true);
+			});
+	},
+} as Component;

--- a/src/components/buttons/image/rotate.ts
+++ b/src/components/buttons/image/rotate.ts
@@ -1,0 +1,38 @@
+import { Component } from "@interfaces/components";
+import { info } from "@helpers/logger";
+import { Client, Message, ButtonInteraction, EmbedBuilder } from "@client";
+import { tileToAttachment, untile } from "@images/tile";
+import { tileButtons } from "@utility/buttons";
+import getImage, { imageNotFound } from "@helpers/getImage";
+import { imageTooBig } from "@helpers/warnUser";
+
+export default {
+	id: "rotate",
+	async execute(client: Client, interaction: ButtonInteraction) {
+		if (client.verbose) console.log(`${info}Image was rotated!`);
+
+		const message = interaction.message;
+		const url = await getImage(message);
+		if (!url) return imageNotFound(interaction);
+		const image = await untile(url);
+		const attachment = await tileToAttachment(image, { random: "rotation", magnify: true });
+
+		if (!attachment) return await imageTooBig(interaction, "tile");
+
+		return interaction
+			.reply({
+				embeds: [
+					new EmbedBuilder()
+						.setImage(`attachment://${attachment.name}`)
+						.setFooter({ text: `${interaction.user.username} | ${interaction.user.id}` })
+						.setTimestamp(),
+				],
+				files: [attachment],
+				components: [tileButtons],
+				fetchReply: true,
+			})
+			.then((message: Message) => {
+				message.deleteButton(true);
+			});
+	},
+} as Component;

--- a/src/helpers/images/tile.ts
+++ b/src/helpers/images/tile.ts
@@ -115,12 +115,7 @@ export async function tile(origin: ImageSource, options: TileOptions = {}): Prom
 			context.clearRect(input.width * 2, 0, input.width, input.height * 3); // right side
 			break;
 	}
-	if (options.magnify) {
-		const { magnified } = await magnify(canvas.toBuffer("image/png"));
-		return magnified;
-	} else {
-		return canvas.toBuffer("image/png");
-	}
+	return canvas.toBuffer("image/png");
 }
 
 /**
@@ -166,7 +161,14 @@ export async function tileToAttachment(
 	name = "tiled.png",
 ) {
 	const buf = await tile(origin, options);
+	let output: Buffer;
 	// image too big so we returned early
 	if (!buf) return null;
-	return new AttachmentBuilder(buf, { name });
+	if (options.magnify) {
+		const { magnified } = await magnify(buf);
+		output = magnified;
+	} else {
+		output = buf;
+	}
+	return new AttachmentBuilder(output, { name });
 }

--- a/src/helpers/images/tile.ts
+++ b/src/helpers/images/tile.ts
@@ -7,12 +7,14 @@ import {
 	StringSelectMenuInteraction,
 	Message,
 } from "@client";
+import { magnify } from "./magnify";
 
-export type TileShape = "grid" | "vertical" | "horizontal" | "hollow" | "plus";
+export type TileShape = "grid" | "vertical" | "horizontal" | "plus";
 export type TileRandom = "flip" | "rotation";
 interface TileOptions {
 	shape?: TileShape;
 	random?: TileRandom;
+	magnify?: boolean;
 }
 
 /**
@@ -98,26 +100,54 @@ export async function tile(origin: ImageSource, options: TileOptions = {}): Prom
 		}
 
 	switch (options.shape) {
-		case "hollow":
-			context.clearRect(input.width, input.height, input.width, input.height); // middle middle
-			break;
 		case "plus":
-		case "horizontal":
-		case "vertical":
 			context.clearRect(0, 0, input.width, input.height); // top left
 			context.clearRect(input.width * 2, 0, input.width, input.height); // top right
 			context.clearRect(input.width * 2, input.height * 2, input.width, input.height); // bottom right
 			context.clearRect(0, input.height * 2, input.width, input.height); // bottom left
 			break;
 		case "horizontal":
-			context.clearRect(input.width, 0, input.width, input.height); // top middle
-			context.clearRect(input.width, input.height * 2, input.width, input.height); // bottom middle
+			context.clearRect(0, 0, input.width * 3, input.height); // top row
+			context.clearRect(0, input.height * 2, input.width * 3, input.height); // bottom row
 			break;
 		case "vertical":
-			context.clearRect(input.width * 2, input.height, input.width, input.height); // middle left
-			context.clearRect(0, input.height, input.width, input.height); // middle right
+			context.clearRect(0, 0, input.width, input.height * 3); // left side
+			context.clearRect(input.width * 2, 0, input.width, input.height * 3); // right side
 			break;
 	}
+	if (options.magnify) {
+		const { magnified } = await magnify(canvas.toBuffer("image/png"));
+		return magnified;
+	} else {
+		return canvas.toBuffer("image/png");
+	}
+}
+
+/**
+ * Untiles an image to get the original image back
+ * @author Superboxer47
+ * @param origin image to untile
+ * @returns original image as buffer
+ */
+export async function untile(origin: ImageSource): Promise<Buffer> {
+	const input = await loadImage(origin);
+
+	const canvas = createCanvas(input.width / 3, input.height / 3);
+	const context = canvas.getContext("2d");
+
+	context.imageSmoothingEnabled = false;
+
+	context.drawImage(
+		input, // image
+		input.width / 3,
+		input.height / 3, // sx, sy
+		input.width / 3,
+		input.height / 3, // sWidth, sHeight
+		0,
+		0, // dx, dy
+		input.width / 3,
+		input.height / 3, // dWidth, dHeight
+	);
 
 	return canvas.toBuffer("image/png");
 }

--- a/src/helpers/images/tile.ts
+++ b/src/helpers/images/tile.ts
@@ -7,7 +7,7 @@ import {
 	StringSelectMenuInteraction,
 	Message,
 } from "@client";
-import { magnify } from "./magnify";
+import { magnifyToAttachment } from "./magnify";
 
 export type TileShape = "grid" | "vertical" | "horizontal" | "plus";
 export type TileRandom = "flip" | "rotation";
@@ -161,14 +161,10 @@ export async function tileToAttachment(
 	name = "tiled.png",
 ) {
 	const buf = await tile(origin, options);
-	let output: Buffer;
 	// image too big so we returned early
 	if (!buf) return null;
 	if (options.magnify) {
-		const { magnified } = await magnify(buf);
-		output = magnified;
-	} else {
-		output = buf;
+		return await magnifyToAttachment(buf);
 	}
-	return new AttachmentBuilder(output, { name });
+	return new AttachmentBuilder(buf, { name });
 }

--- a/src/helpers/prefixCommandHandler.ts
+++ b/src/helpers/prefixCommandHandler.ts
@@ -3,7 +3,7 @@ import { magnifyToAttachment } from "./images/magnify";
 import getImage, { imageNotFound } from "./getImage";
 import { tileToAttachment } from "./images/tile";
 import { paletteToAttachment } from "./images/palette";
-import { imageButtons, magnifyButtons } from "@utility/buttons";
+import { magnifyButtons, tileButtons } from "@utility/buttons";
 import { imageTooBig } from "./warnUser";
 
 export default async function prefixCommandHandler(message: Message) {
@@ -33,7 +33,7 @@ export default async function prefixCommandHandler(message: Message) {
 			const file = await tileToAttachment(url);
 			if (!file) return await imageTooBig(message, "tile");
 			return await message
-				.reply({ files: [file], components: [imageButtons] })
+				.reply({ files: [file], components: [tileButtons] })
 				.then((message: Message) => message.deleteButton());
 		case "p":
 			const [attachment, embed] = await paletteToAttachment(url);

--- a/src/helpers/utility/buttons.ts
+++ b/src/helpers/utility/buttons.ts
@@ -17,6 +17,14 @@ export const tile = new ButtonBuilder()
 	.setStyle(ButtonStyle.Primary)
 	.setEmoji(emojis.tile)
 	.setCustomId("tile");
+export const flip = new ButtonBuilder()
+	.setStyle(ButtonStyle.Primary)
+	.setEmoji(emojis.flip)
+	.setCustomId("flip");
+export const rotate = new ButtonBuilder()
+	.setStyle(ButtonStyle.Primary)
+	.setEmoji(emojis.rotate)
+	.setCustomId("rotate");
 
 export const template = new ButtonBuilder()
 	.setStyle(ButtonStyle.Primary)
@@ -78,6 +86,12 @@ export const magnifyButtons = new ActionRowBuilder<ButtonBuilder>().addComponent
 export const imageButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(
 	magnify,
 	tile,
+	palette,
+);
+export const tileButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+	tile,
+	flip,
+	rotate,
 	palette,
 );
 export const textureButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(


### PR DESCRIPTION
Closes #271 — This new code would add two new buttons below the output of the tile function, allowing you to rotate and flip at the click of a button. It also auto-magnifies all tile outputs, unless otherwise specified. (It also fixed tiling in special patterns not working properly and removed hollow style for the new code to work (it wasn't very useful anyway))